### PR TITLE
remove clickPlain(); fixes #26

### DIFF
--- a/keybindings.lua
+++ b/keybindings.lua
@@ -607,5 +607,4 @@ function cleanShape()
   clickEllipse(false)
   clickSpline(false)
   clickFill(false)
-  clickPlain()
 end


### PR DESCRIPTION
`clickPlain()` is causing pen click after selecting the desired tool for each tool that uses `cleanShape()`